### PR TITLE
Update gradle file for Kotlin 1.0.0

### DIFF
--- a/subskription/build.gradle
+++ b/subskription/build.gradle
@@ -26,13 +26,13 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'io.reactivex:rxjava:1.1.0'
-    compile 'io.reactivex:rxkotlin:0.30.1'
+    compile 'io.reactivex:rxjava:1.1.1'
+    compile 'io.reactivex:rxkotlin:0.40.1'
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }
 
 buildscript {
-    ext.kotlin_version = '1.0.0-beta-3595'
+    ext.kotlin_version = '1.0.0'
     repositories {
         jcenter()
         mavenCentral()


### PR DESCRIPTION
The following error After building my project Kotlin1.0.0 came out.

```
app/build/intermediates/exploded-aar/com.github.yamamotoj/subskription
/0.2.1/jars/classes.jar!/com/github/yamamotoj/subskription/AutoUnsubscri
bableDelegate.class: Class 'com/github/yamamotoj/subskription/AutoUns
ubscribableDelegate' was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 1.0.0, expected version is 1.1.0
```

So I did modify the gradle script so as to pass through the build on Kotlin 1.0.0.
